### PR TITLE
Fix false FALoginCookieError

### DIFF
--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -260,7 +260,7 @@ module FAExport
       end
 
       def ensure_login!
-        return if @user_cookie
+        return if !@user_cookie
 
         raise FALoginCookieError.new(
           'You must provide a valid login cookie in the header "FA_COOKIE".'\


### PR DESCRIPTION
The `ensure_login!` method was always returning the `FALoginCookieError` due to the `@user_cookie` returning true, so I just made it false so it won't return the error.